### PR TITLE
Adds write functionality with minor bugs

### DIFF
--- a/include/filesys.h
+++ b/include/filesys.h
@@ -91,3 +91,4 @@ void formatDirectoryName(char* dest, const char* src);
 DirectoryEntry* makeDirEntry(void* clustStart);
 unsigned int getHILO(DirectoryEntry *entry);
 DirEntryList* establishRoot(FAT32FileSystem* fs);
+unsigned long getClusterOffset(FAT32FileSystem*, unsigned int);

--- a/include/filesys.h
+++ b/include/filesys.h
@@ -79,7 +79,8 @@ void getBytestoChar(unsigned int offset, unsigned int size, char* string);
 unsigned int makeBigEndian(unsigned char *array, int bytes);
 void readCluster(FAT32FileSystem* fs, unsigned int clusterNumber, void* buffer);
 void writeCluster(FAT32FileSystem* fs, unsigned int clusterNumber, void* buffer);
-DirectoryEntry* findDirectoryCluster(const void* buffer, const char* name);
+// Modified this to enable locating files, since directories and file follow the same structure
+DirectoryEntry* findDirectoryCluster(const void* buffer, const char* name, bool isDir);
 unsigned int findFreeCluster(FAT32FileSystem* fs);
 // poor implementation of directory entry for full project use :/
 int addDirectoryEntry(FAT32FileSystem* fs, unsigned int directoryCluster, const char* entryName, unsigned int entryCluster, int isDirectory);

--- a/include/navigate.h
+++ b/include/navigate.h
@@ -6,8 +6,8 @@
 
 bool cd(FAT32FileSystem* fs, const char* dirname) {
     unsigned char* buffer = (unsigned char*)(malloc(fs->BPB_BytsPerSec * fs->BPB_SecPerClus));
-    DirectoryEntry* newDir= findDirectoryCluster(buffer, dirname);
     readCluster(fs, getCurrCluster(fs), buffer);
+    DirectoryEntry* newDir = findDirectoryCluster(buffer, dirname, true);
 
     if (newDir == NULL) {
         printf("Directory not found: %s\n", dirname);

--- a/include/openFileEntry.h
+++ b/include/openFileEntry.h
@@ -9,6 +9,6 @@ typedef struct {
     unsigned int offset;        // Current offset in the file
     unsigned int fileCluster;   // start cluster of file
     bool inUse;                 // Indicates if the entry is in use
-    char path[128];            // Just keep path as a string for simplicity
+    char path[128];             // Just keep path as a string for simplicity
     unsigned int fileSize;
 } OpenFileEntry;

--- a/src/create.c
+++ b/src/create.c
@@ -18,7 +18,7 @@ void mkdir(FAT32FileSystem* fs, const char* dirname) {
     readCluster(fs, getCurrCluster(fs), clusterBuffer);
 
     // Check if the directory already exists
-    unsigned int dirCluster = findDirectoryCluster(clusterBuffer, dirname);
+    unsigned int dirCluster = findDirectoryCluster(clusterBuffer, dirname, true);
     if (dirCluster != 0) {
         printf("Error: Directory or file named '%s' already exists.\n", dirname);
         free(clusterBuffer);

--- a/src/create.c
+++ b/src/create.c
@@ -1,4 +1,4 @@
-#include "filesys.h"
+#include "create.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/filesys.c
+++ b/src/filesys.c
@@ -88,13 +88,13 @@ void readCluster(FAT32FileSystem* fs, unsigned int clusterNumber, void* buffer) 
     fread(buffer, fs->BPB_BytsPerSec, fs->BPB_SecPerClus, fs->imageFile);
 }
 
-DirectoryEntry* findDirectoryCluster(const void* buffer, const char* name) {
+DirectoryEntry* findDirectoryCluster(const void* buffer, const char* name, bool isDir) {
     char formattedName[12];
     formatDirectoryName(formattedName, name);  // Make sure this uses the same formatting as in `addDirectoryEntry`
 
     const unsigned char* p = buffer;
     while (*p != 0 && *p != 0xE5) {  // Continue past deleted entries
-        if ((p[11] & ATTR_DIRECTORY) && !(p[11] & ATTR_VOLUME_ID)) {
+        if (isDir ? (p[11] & ATTR_DIRECTORY) && !(p[11] & ATTR_VOLUME_ID) : (p[11] & ATTR_ARCHIVE)) {
             if (strncmp((const char*)p, formattedName, 11) == 0) {
                 return makeDirEntry((void*)p);
             }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -8,6 +8,7 @@
 void lexer(FAT32FileSystem* fs)
 {	
 	char path[256] = "fat32.img";
+	char buffer[12];
 	bool valid;
 	while (1) {
 		// FIXME: Find a way to show path from inside filesystem

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1,6 +1,7 @@
 #include "lexer.h"
 #include "info.h"
 #include "navigate.h"
+#include "write.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -109,6 +110,18 @@ void lexer(FAT32FileSystem* fs)
 				else {
 					unsigned int size = atoi(tokens->items[2]); // Convert size from string to integer
 					readCommand(fs, tokens->items[1], size);
+				}
+			}
+			else if (strcmp(tokens->items[0], "write") == 0) {
+				if (tokens->size < 3) {
+					printf("Usage: write [FILENAME] [STRING]\n");
+				}
+				else{
+					for (int i = 3; i < tokens->size; i++) {
+						strcat(tokens->items[2]," ");
+						strcat(tokens->items[2], tokens->items[i]);
+					}
+					writeHandler(fs, tokens->items[1], tokens->items[2]);
 				}
 			}
 			else{

--- a/src/read.c
+++ b/src/read.c
@@ -217,13 +217,7 @@ void readCommand(FAT32FileSystem* fs, const char* filename, unsigned int size) {
 }
 
 unsigned int readFile(FAT32FileSystem* fs, unsigned int startCluster, unsigned int offset, unsigned char* buffer, unsigned int bytesToRead) {
-    // Convert offset to cluster number (assuming offset is within file size limits, already checked)
-    unsigned long rootDirOffset = fs->BPB_RsvdSecCnt * fs->BPB_BytsPerSec + fs->BPB_NumFATs * fs->BPB_FATSz32 * fs->BPB_BytsPerSec;
-    unsigned long clusterOffset = rootDirOffset + (((startCluster >> 16) & 0xFFFF) - 2) * fs->BPB_SecPerClus * fs->BPB_BytsPerSec
-                                 + (startCluster & 0xFFFF) * fs->BPB_BytsPerSec + offset;
-    // I dont know why, but the above calculation adds a 1 in the 16^9 place that shouldn't be there, so this should fix it
-    // but longs should only be 8 bytes, how can there be anything in the 16^9 place?
-    clusterOffset = clusterOffset & 0xFFFFFFFF;
+    unsigned long clusterOffset = getClusterOffset(fs, startCluster);
     fseek(fs->imageFile, clusterOffset, SEEK_SET);
 
     // Adjust read size if it goes beyond the file size (this requires knowing the file size which should be managed elsewhere)
@@ -248,4 +242,3 @@ char* getPath(char* path, FAT32FileSystem* fs) {
 
     return path;
 }
-


### PR DESCRIPTION
One such bug is that there must be a way to write-over the file size portion of a files metadata in the fileImage. With our current functions I am unsure if there is a simple way to do this. 
Another bug is being able to mark multiple files as open in different modes, messing up reading and writing based on order of which is what done. That's a much easier fix.